### PR TITLE
use branch name for image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,19 @@ SHELL := /bin/bash
 export PROJECT_DIR            = $(shell 'pwd')
 export PROJECT_NAME			  = $(shell basename ${PROJECT_DIR})
 
+# set docker image tag to branch name or "latest" if "master" or "main" branch
+GIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+IMG_TAG = ${GIT_BRANCH}
+ifeq ("main",${IMG_TAG})
+IMG_TAG = latest
+endif
+ifeq ("master",${IMG_TAG})
+IMG_TAG = latest
+endif
+
 # Image URL to use all building/pushing image targets
-IMG ?= ${PROJECT_NAME}:latest
-IMG_COVERAGE ?= ${PROJECT_NAME}-coverage:latest
+IMG ?= ${PROJECT_NAME}:${IMG_TAG}
+IMG_COVERAGE ?= ${PROJECT_NAME}-coverage:${IMG_TAG}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 


### PR DESCRIPTION
Part of the solution to https://github.com/open-cluster-management/backlog/issues/15800

We need every image built in a specific branch and tagged according to the branch name.  

Feature work should happen in a feature branch.

Builds that occur in the "master" or "main" branch will have their tag set to "latest"

once every image used in our operator is tagging like this we will be able to consistently reference the images we need in our bundle to be able to create a proper OLM catalog source deployment.