### PR TITLE
temp. pin dex-operator to working version

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
             - -v 5
           env:
             - name: RELATED_IMAGE_DEX_OPERATOR
-              value: "quay.io/identitatem/dex-operator:latest"
+              value: "quay.io/identitatem/dex-operator@sha256:907bf03e5b369c719ea770fdd27d4fc0214b65925b78f4725f485a337a79920f"
           image: quay.io/identitatem/idp-mgmt-operator:latest
           name: manager
           imagePullPolicy: Always


### PR DESCRIPTION
Signed-off-by: Chris Ahl <cahl@redhat.com>

Need to pin the dex-operator image until a fix is made to latest.  