### PR TITLE
Add a release job for generating release tagged images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, release-* ]
 
 jobs:
-  test:
+  publish:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 name: Create Release
 
 jobs:
-  test:
+  release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
       with:
         go-version: 1.16
 
-    - name: Install Dependencies and Publish
+    - name: Publish a release tagged image
       env:
         DOCKER_USER: ${{ secrets.DOCKER_USER }}
         DOCKER_PASS: ${{ secrets.DOCKER_PASS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+# Copyright Contributors to the Open Cluster Management project
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - '[0-9]*.[0-9]*.[0-9]*' # Push events matching semver tags
+
+name: Create Release
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Install Dependencies and Publish
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+      run: |
+        export VERSION=${GITHUB_REF##*/}
+        export IMG_TAG=${GITHUB_REF##*/}
+        make publish


### PR DESCRIPTION
## Summary of Changes

This PR adds a GitHub action that runs when a new repo tag is created in SemVer format and generates a bundle and catalog for that version of the project with the SemVer tag in use.  

I've also fixed a naming in-elegance in the publish action.