### PR TITLE
only run github action publish job on non-fork repos

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    if: github.repository_owner = 'identitatem'
+    if: github.repository_owner == 'identitatem'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Chris Ahl <cahl@redhat.com>

For issue https://github.com/open-cluster-management/backlog/issues/17468