### PR TITLE
copy CertificatesSecretRef type to dex server namespace

### DIFF
--- a/controllers/authrealm/dex.go
+++ b/controllers/authrealm/dex.go
@@ -317,7 +317,7 @@ func (r *AuthRealmReconciler) updateDexServer(authRealm *identitatemv1alpha1.Aut
 					Name:      certSecret.Name,
 					Namespace: dexServer.Namespace,
 				},
-				Type: corev1.SecretTypeOpaque,
+				Type: certSecret.Type,
 				Data: certSecret.Data,
 			}
 			if err := r.Client.Create(context.TODO(), dexServerCertSecret); err != nil {
@@ -325,6 +325,7 @@ func (r *AuthRealmReconciler) updateDexServer(authRealm *identitatemv1alpha1.Aut
 			}
 		} else {
 			dexServerCertSecret.Data = certSecret.Data
+			dexServerCertSecret.Type = certSecret.Type
 			if err := r.Client.Update(context.TODO(), dexServerCertSecret); err != nil {
 				return giterrors.WithStack(err)
 			}


### PR DESCRIPTION
Rather than hardcoding to secret type Opaque, which does not work, use the type of the secret in the authrealm namespace, which I assume will always be tls and we will write the directions as such. The other option was to hardcode the type to `kubernetes.io/tls` but I wasn't entirely sure if perhaps there was some other cert secret type that would also be valid, and the selected implementation is more flexible.

Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>