### PR TITLE
Default VERSION in Makefile to include a timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ IMG_COVERAGE ?= ${PROJECT_NAME}-coverage:${IMG_TAG}
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 
 # Version to apply to generated artifacts (for bundling/publishing)
-export VERSION ?= 0.1.1
+export VERSION ?= 0.1.1-$(shell date -u +'%Y%m%d-%H-%M-%S')
 
 # Bundle Prereqs
 IMAGE_TAG_BASE ?= quay.io/identitatem/$(PROJECT_NAME)


### PR DESCRIPTION
Currently on each push to main we are pushing bundle and catalog
images with version 0.1.1. Instead, we want to default to including
a timestamp to produce a distinct image on each push.

Issue: open-cluster-management/backlog#18208

Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>