### PR TITLE
Revert the previous VERSION change and set in GitHub publish action

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,6 +1,6 @@
 # Copyright Red Hat
 
-name: Go
+name: Functional Tests
 
 on:
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 # Copyright Red Hat
 
-name: Go
+name: Publish
 
 on:
   push:
@@ -22,4 +22,6 @@ jobs:
       env:
         DOCKER_USER: ${{ secrets.DOCKER_USER }}
         DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
-      run: make publish
+      run: |
+        export VERSION="0.1.1-$(date -u +'%Y%m%d-%H-%M-%S')"
+        make publish

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ IMG_COVERAGE ?= ${PROJECT_NAME}-coverage:${IMG_TAG}
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 
 # Version to apply to generated artifacts (for bundling/publishing)
-export VERSION ?= 0.1.1-$(shell date -u +'%Y%m%d-%H-%M-%S')
+export VERSION ?= 0.1.1
 
 # Bundle Prereqs
 IMAGE_TAG_BASE ?= quay.io/identitatem/$(PROJECT_NAME)


### PR DESCRIPTION
Original fix didn't work because the VERSION changed between make steps. Instead we will set the VERSION in the GitHub action (i.e. outside the Makefile).

Issue: open-cluster-management/backlog#18208