### PR TITLE
Editing the GitHub OAuth app redirect URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ kind_kubeconfig_internal.yaml
 
 # bundle/manifests/idp-mgmt-operator.clusterserviceversion.yaml
 /test/e2e/utils/kcfg.yaml
+test/e2e/cypress-ui/node_modules/

--- a/test/e2e/cypress-ui/README.md
+++ b/test/e2e/cypress-ui/README.md
@@ -17,6 +17,24 @@
 3. Run `npx cypress open` to run your test in headed mode.
 4. Select test to run.
 
+## Adjust Redirect URI in GitHub
+
+* Export the following environment variables:
+```bash
+# URL to the GitHub OAuth apps UI
+export CYPRESS_OPTIONS_GH_OAUTH_APPS_URL=...
+# Name of the GitHub OAuth App
+export CYPRESS_OPTIONS_GH_OAUTH_APPNAME=...
+# GitHub login user
+export CYPRESS_OPTIONS_GH_USER=...
+# GitHub login password
+export CYPRESS_OPTIONS_GH_PASSWORD=...
+# GitHub OAuth Homepage URL constructed using route subdomain and Hub cluster URL
+export CYPRESS_OPTIONS_GH_OAUTH_HOMEPAGE_URL=...
+# GitHub OAuth callback URL constructed using route subdomain and Hub cluster URL
+export CYPRESS_OPTIONS_GH_OAUTH_CALLBACK_URL=...
+```
+
 ### Running in Headless Mode
 - If you want to run in headless mode and tag a specific test, instead of doing `npx cypress open`, try this instead:
     - `npx cypress run --headless --reporter cypress-multi-reporters --env grepTags=<test-tag>,grepFilterSpecs=true,grepOmitFiltered=true`

--- a/test/e2e/cypress-ui/cypress/support/commands.js
+++ b/test/e2e/cypress-ui/cypress/support/commands.js
@@ -170,7 +170,7 @@ Cypress.Commands.add('loginToGitHubOAuthApp', (OPTIONS_GH_OAUTH_APPS_URL, OPTION
 
       // Sign in
       cy.get('input[name=login]').type(username);
-      cy.get('input[name=password]').type(`${password}{enter}`);
+      cy.get('input[name=password]').type(`${password}{enter}`, { log:false });
 
       // Should be signed in
       cy.get(`header > div > details > summary > img[alt="@${username}"]`, { timeout: 10000 }).should('exist');

--- a/test/e2e/cypress-ui/cypress/support/constants.js
+++ b/test/e2e/cypress-ui/cypress/support/constants.js
@@ -16,8 +16,8 @@ export const clusterpools_path = "/clusterpools"
 export const clusterclaims_path = "/clusterclaims"
 
 // API URL
-export const apiUrl = Cypress.config().baseUrl.replace("multicloud-console.apps", "api") + ":6443";
-export const ocpUrl = Cypress.config().baseUrl.replace("multicloud-console.apps", "console-openshift-console.apps");
-export const prometheusUrl = Cypress.config().baseUrl.replace("multicloud-console.apps", "prometheus-k8s-openshift-monitoring.apps");
+export const apiUrl = Cypress.config().baseUrl;
+export const ocpUrl = Cypress.config().baseUrl;
+export const prometheusUrl = Cypress.config().baseUrl;
 
 export const supportedOCPReleasesRegex = "4.6|4.8|4.9|4.10"

--- a/test/e2e/cypress-ui/cypress/tests/adjustGitHubOAuthRedirect.spec.js
+++ b/test/e2e/cypress-ui/cypress/tests/adjustGitHubOAuthRedirect.spec.js
@@ -2,7 +2,7 @@
 
 /// <reference types="cypress" />
 describe('Adjust GitHub OAuth Redirect', {
-    tags: ['@IDP', 'tag-test']
+    tags: ['@IDP', 'tag-gh-oauth-redirect']
 }, function () {
     it('Update homepage and callback URLs for the GitHub OAuth app', { tags: [] }, function () {         // These steps need to be in a single spec since Cypress clears out cookies between specs
         // Login to GitHub

--- a/test/e2e/cypress-ui/cypress/tests/adjustGitHubOAuthRedirect.spec.js
+++ b/test/e2e/cypress-ui/cypress/tests/adjustGitHubOAuthRedirect.spec.js
@@ -4,7 +4,7 @@
 describe('Adjust GitHub OAuth Redirect', {
     tags: ['@IDP', 'tag-test']
 }, function () {
-    it('Open the GitHub OAuth app', { tags: [] }, function () {         // These steps need to be in a single spec since Cypress clears out cookies between specs
+    it('Update homepage and callback URLs for the GitHub OAuth app', { tags: [] }, function () {         // These steps need to be in a single spec since Cypress clears out cookies between specs
         // Login to GitHub
         cy.loginToGitHubOAuthApp()
 

--- a/test/e2e/cypress-ui/cypress/tests/adjustGitHubOAuthRedirect.spec.js
+++ b/test/e2e/cypress-ui/cypress/tests/adjustGitHubOAuthRedirect.spec.js
@@ -1,0 +1,36 @@
+/* Copyright Red Hat */
+
+/// <reference types="cypress" />
+describe('Adjust GitHub OAuth Redirect', {
+    tags: ['@IDP', 'tag-test']
+}, function () {
+    it('Open the GitHub OAuth app', { tags: [] }, function () {         // These steps need to be in a single spec since Cypress clears out cookies between specs
+        // Login to GitHub
+        cy.loginToGitHubOAuthApp()
+
+        // The OAuth apps page is currently open
+        cy.contains('h2', 'OAuth Apps').should('exist');
+
+        // Open the UI for the specific OAuth app
+        var oauthAppName = Cypress.env('OPTIONS_GH_OAUTH_APPNAME')
+        cy.contains('a.text-bold', oauthAppName).click();
+        cy.contains('h2', oauthAppName).should('exist');
+
+        // Change OAuth Callback URL
+        var oauthCallbackURL = Cypress.env('OPTIONS_GH_OAUTH_CALLBACK_URL');
+        cy.get('input[name="oauth_application[callback_url]"]').clear();
+        cy.get('input[name="oauth_application[callback_url]"]').type(oauthCallbackURL);
+
+        // Change OAuth Homepage URL
+        var oauthHomepageURL = Cypress.env('OPTIONS_GH_OAUTH_HOMEPAGE_URL');
+        cy.get('input[name="oauth_application[url]"]').clear();
+        cy.get('input[name="oauth_application[url]"]').type(oauthHomepageURL);     
+
+        // Update
+        cy.get('form.edit_oauth_application > button[type=submit]').click();
+        cy.wait(1000)      
+        
+        // Logout of GitHub
+        cy.logoutOfGitHub();
+    });
+})

--- a/test/e2e/start-cypress-tests.sh
+++ b/test/e2e/start-cypress-tests.sh
@@ -58,7 +58,7 @@ testCode=0
 TEST_TAG=login
 npm install
 #Turn off color ascii output when we run
-NO_COLOR=1 npx cypress run --browser $BROWSER --reporter cypress-multi-reporters --env grepTags=${TEST_TAG},grepFilterSpecs=true,grepOmitFiltered=true
+NO_COLOR=1 npx cypress run --browser $BROWSER --reporter cypress-multi-reporters
 testCode=$?
 
 testDirectory="/results"


### PR DESCRIPTION
Signed-off-by: Vidya Nambiar <vnambiar@redhat.com>

ZenHub: https://github.com/stolostron/backlog/issues/19182

To test:

- Run `npx cypress open` and click on the `adjustGitHubOAuthRedirect.spec.js` spec.
- The Readme contains the additional environment variables that will be required.
- I have tested this by creating a new GitHub user that does not implement 2FA and by creating an org and OAuth app under that org. Please DM me for values of the environment variables if you'd like to test this out.