### PR TITLE
update go.mod - to add easy logging for dex-server

### DIFF
--- a/config/installer/installer.yaml
+++ b/config/installer/installer.yaml
@@ -49,7 +49,7 @@ spec:
         - installer
         env:
         - name: RELATED_IMAGE_DEX_OPERATOR
-          value: "quay.io/identitatem/dex-operator:0.2.0-20220117-21-48-21"
+          value: "quay.io/identitatem/dex-operator:0.1-f82645dbefa2e0a634186e662adf139cff60523b"
         - name: RELATED_IMAGE_DEX_SERVER
           value: ghcr.io/dexidp/dex:v2.30.2
         - name: POD_NAME

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v1.2.0
-	github.com/identitatem/dex-operator v0.0.4-0.20220127195054-da4176e7900f
+	github.com/identitatem/dex-operator v0.0.4-0.20220204192727-f82645dbefa2
 	github.com/identitatem/idp-client-api v0.0.0-20220128181808-d06576428b4d
 	github.com/onsi/ginkgo/v2 v2.1.1
 	github.com/onsi/gomega v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -496,8 +496,8 @@ github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/identitatem/dex-operator v0.0.4-0.20220127195054-da4176e7900f h1:BZJKd0wLB8df4iX+dWJ8ZZ4Q6TrSS/UTiSTOiY1p00o=
-github.com/identitatem/dex-operator v0.0.4-0.20220127195054-da4176e7900f/go.mod h1:uAcCS2K+XkfB2gJjC5LOPJBvnWAAQumRbtXJ2bpP8is=
+github.com/identitatem/dex-operator v0.0.4-0.20220204192727-f82645dbefa2 h1:T7wkFeIdlCgn1D/eaHJSK/yyIPODm9y5Y5U9pZNq8jE=
+github.com/identitatem/dex-operator v0.0.4-0.20220204192727-f82645dbefa2/go.mod h1:uAcCS2K+XkfB2gJjC5LOPJBvnWAAQumRbtXJ2bpP8is=
 github.com/identitatem/idp-client-api v0.0.0-20220128181808-d06576428b4d h1:pXGy4k8rp/yZC0aP7wK8l3dTuGBBRVY2/8B88Pr8yx0=
 github.com/identitatem/idp-client-api v0.0.0-20220128181808-d06576428b4d/go.mod h1:KyzKCajvk+RMr9pBDRm3+lWAj3cTK/NgE0fKlTBoh/E=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=


### PR DESCRIPTION
Signed-off-by: Leena Jawale <ljawale@redhat.com>

Updated go.mod dex-operator dependency to add easy logging for dex-server pod