### PR TITLE
GITHUB_REF update to GITHUB_REF_NAME in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,6 @@ jobs:
         DOCKER_USER: ${{ secrets.DOCKER_USER }}
         DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
       run: |
-        export VERSION="0.0.1-$(date -u +'%Y%m%d-%H-%M-%S')-${GITHUB_SHA::7}-${GITHUB_REF}"
+        export VERSION="0.0.1-$(date -u +'%Y%m%d-%H-%M-%S')-${GITHUB_SHA::7}-${GITHUB_REF_NAME}"
         export KUBEBUILDER_ASSETS=$HOME/kubebuilder/bin;
         make publish PUSH_LATEST=true


### PR DESCRIPTION
GITHUB_REF includes /refs/heads. I should have used GITHUB_REF_NAME to just get the branch name.

stolostron/backlog#17826
stolostron/backlog#18208

Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>