### PR TITLE
Update clusteroauth on authrealm change

### DIFF
--- a/controllers/clusteroauth/clusteroauth_controller.go
+++ b/controllers/clusteroauth/clusteroauth_controller.go
@@ -284,6 +284,9 @@ func (r *ClusterOAuthReconciler) generateManifestWork(clusterOAuth *identitatemv
 
 	for _, clusterOAuth := range clusterOAuths.Items {
 		//build OAuth and add to manifest work
+		if clusterOAuth.DeletionTimestamp != nil {
+			continue
+		}
 		r.Log.Info(" build clusterOAuth", "name: ", clusterOAuth.GetName(), " namespace:", clusterOAuth.GetNamespace(), "identityProviders:", len(clusterOAuth.Spec.OAuth.Spec.IdentityProviders))
 
 		for j, idp := range clusterOAuth.Spec.OAuth.Spec.IdentityProviders {
@@ -296,7 +299,10 @@ func (r *ClusterOAuthReconciler) generateManifestWork(clusterOAuth *identitatemv
 	}
 
 	for _, clusterOAuth := range clusterOAuths.Items {
-		//build OAuth and add to manifest work
+		//build Secrets and add to manifest work
+		if clusterOAuth.DeletionTimestamp != nil {
+			continue
+		}
 		r.Log.Info(" build clusterOAuth", "name: ", clusterOAuth.GetName(), " namespace:", clusterOAuth.GetNamespace(), "identityProviders:", len(clusterOAuth.Spec.OAuth.Spec.IdentityProviders))
 
 		for _, idp := range clusterOAuth.Spec.OAuth.Spec.IdentityProviders {
@@ -420,6 +426,10 @@ func (r *ClusterOAuthReconciler) unmanagedCluster(clusterOAuth *identitatemv1alp
 		if err := r.deleteManifestWork(helpers.ManifestWorkOriginalOAuthName(), clusterOAuth.Namespace); err != nil {
 			return ctrl.Result{}, err
 		}
+		return ctrl.Result{}, nil
+	}
+	if err := r.generateManifestWork(clusterOAuth); err != nil {
+		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
Signed-off-by: Dominique Vernier <dvernier@redhat.com>

[Update authrealm doesn't update the clusterOAuth](https://github.com/stolostron/backlog/issues/20165)
[When a AuthRealm is deleted the manifestwork is not updated](https://github.com/stolostron/backlog/issues/20334)