### PR TITLE
Return error when Get failed

### DIFF
--- a/controllers/clusteroauth/clusteroauth_controller.go
+++ b/controllers/clusteroauth/clusteroauth_controller.go
@@ -398,7 +398,7 @@ func (r *ClusterOAuthReconciler) CreateOrUpdateManifestWork(
 		}
 		return nil
 	}
-	return nil
+	return err
 }
 
 // unmanagedCluster deletes a manifestwork


### PR DESCRIPTION
Signed-off-by: Dominique Vernier <dvernier@redhat.com>

return an error if the Get failed when checking if an update or create manifestwork must be done